### PR TITLE
Initial code/meta/docs copied from the JSON codec and modified to suit

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing to Logstash
+
+All contributions are welcome: ideas, patches, documentation, bug reports,
+complaints, etc!
+
+Programming is not a required skill, and there are many ways to help out!
+It is more important to us that you are able to contribute.
+
+That said, some basic guidelines, which you are free to ignore :)
+
+## Want to learn?
+
+Want to lurk about and see what others are doing with Logstash? 
+
+* The irc channel (#logstash on irc.freenode.org) is a good place for this
+* The [forum](https://discuss.elastic.co/c/logstash) is also
+  great for learning from others.
+
+## Got Questions?
+
+Have a problem you want Logstash to solve for you? 
+
+* You can ask a question in the [forum](https://discuss.elastic.co/c/logstash)
+* Alternately, you are welcome to join the IRC channel #logstash on
+irc.freenode.org and ask for help there!
+
+## Have an Idea or Feature Request?
+
+* File a ticket on [GitHub](https://github.com/elastic/logstash/issues). Please remember that GitHub is used only for issues and feature requests. If you have a general question, the [forum](https://discuss.elastic.co/c/logstash) or IRC would be the best place to ask.
+
+## Something Not Working? Found a Bug?
+
+If you think you found a bug, it probably is a bug.
+
+* If it is a general Logstash or a pipeline issue, file it in [Logstash GitHub](https://github.com/elasticsearch/logstash/issues)
+* If it is specific to a plugin, please file it in the respective repository under [logstash-plugins](https://github.com/logstash-plugins)
+* or ask the [forum](https://discuss.elastic.co/c/logstash).
+
+# Contributing Documentation and Code Changes
+
+If you have a bugfix or new feature that you would like to contribute to
+logstash, and you think it will take more than a few minutes to produce the fix
+(ie; write code), it is worth discussing the change with the Logstash users and developers first! You can reach us via [GitHub](https://github.com/elastic/logstash/issues), the [forum](https://discuss.elastic.co/c/logstash), or via IRC (#logstash on freenode irc)
+Please note that Pull Requests without tests will not be merged. If you would like to contribute but do not have experience with writing tests, please ping us on IRC/forum or create a PR and ask our help.
+
+## Contributing to plugins
+
+Check our [documentation](https://www.elastic.co/guide/en/logstash/current/contributing-to-logstash.html) on how to contribute to plugins or write your own! It is super easy!
+
+## Contribution Steps
+
+1. Test your changes! [Run](https://github.com/elastic/logstash#testing) the test suite
+2. Please make sure you have signed our [Contributor License
+   Agreement](https://www.elastic.co/contributor-agreement/). We are not
+   asking you to assign copyright to us, but to give us the right to distribute
+   your code without restriction. We ask this of all contributors in order to
+   assure our users of the origin and continuing existence of the code. You
+   only need to sign the CLA once.
+3. Send a pull request! Push your changes to your fork of the repository and
+   [submit a pull
+   request](https://help.github.com/articles/using-pull-requests). In the pull
+   request, describe what your changes do and mention any bugs/issues related
+   to the pull request.
+
+

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,9 @@
+Please post all product and debugging questions on our [forum](https://discuss.elastic.co/c/logstash). Your questions will reach our wider community members there, and if we confirm that there is a bug, then we can open a new issue here.
+
+For all general issues, please provide the following details for fast resolution:
+
+- Version:
+- Operating System:
+- Config File (if you have sensitive info, please remove it):
+- Sample Data:
+- Steps to Reproduce:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,1 @@
+Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.gem
+Gemfile.lock
+.bundle

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+---
+sudo: false
+language: ruby
+cache: bundler
+env: 
+rvm:
+- jruby-1.7.25
+matrix:
+  include:
+  - rvm: jruby-9.1.10.0
+    env: LOGSTASH_BRANCH=master
+  - rvm: jruby-9.1.10.0
+    env: LOGSTASH_BRANCH=6.x
+  - rvm: jruby-1.7.25
+    env: LOGSTASH_BRANCH=5.6
+  fast_finish: true
+install: true
+script: ci/build.sh
+jdk: oraclejdk8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 1.0.0
+  - Initial release
+  - This codec is intended for use with inputs, like redis or kafka, that produce a single string 'record' - this can be a JSON array of objects or a JSON object that can span multiple lines.
+  - It is not intended for use with inputs, like tcp or file, that produce multiple records (events) separated with a newline. These inputs pass fixed size chunks of text to the codec - if your object is larger than the fixed size, you will get a parse failure. 
+  - This codec is intended for use with outputs to produce a pretty printed JSON string.

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,18 @@
+The following is a list of people who have contributed ideas, code, bug
+reports, or in general have helped logstash along its way.
+
+Contributors:
+* Colin Surprenant (colinsurprenant)
+* Jordan Sissel (jordansissel)
+* João Duarte (jsvd)
+* Kurt Hurtado (kurtado)
+* Nick Ethier (nickethier)
+* Pier-Hugues Pellerin (ph)
+* Richard Pijnenburg (electrical)
+* Tal Levy (talevy)
+* Guy Boertje (guyboertje)
+
+Note: If you've sent us patches, bug reports, or otherwise contributed to
+Logstash, and you aren't on the list above and want to be, please let us know
+and we'll make sure you're here. Contributions from folks like you are what make
+open source awesome.

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,11 @@
+source 'https://rubygems.org'
+
+gemspec
+
+logstash_path = ENV["LOGSTASH_PATH"] || "../../logstash"
+use_logstash_source = ENV["LOGSTASH_SOURCE"] && ENV["LOGSTASH_SOURCE"].to_s == "1"
+
+if Dir.exist?(logstash_path) && use_logstash_source
+  gem 'logstash-core', :path => "#{logstash_path}/logstash-core"
+  gem 'logstash-core-plugin-api', :path => "#{logstash_path}/logstash-core-plugin-api"
+end

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright (c) 2012–2016 Elasticsearch <http://www.elastic.co>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/NOTICE.TXT
+++ b/NOTICE.TXT
@@ -1,0 +1,5 @@
+Elasticsearch
+Copyright 2012-2015 Elasticsearch
+
+This product includes software developed by The Apache Software
+Foundation (http://www.apache.org/).

--- a/README.md
+++ b/README.md
@@ -1,1 +1,98 @@
-# logstash-codec-json-pretty
+# Logstash Plugin
+
+[![Travis Build Status](https://travis-ci.org/logstash-plugins/logstash-codec-json.svg)](https://travis-ci.org/logstash-plugins/logstash-codec-json)
+
+This is a plugin for [Logstash](https://github.com/elastic/logstash).
+
+It is fully free and fully open source. The license is Apache 2.0, meaning you are pretty much free to use it however you want in whatever way.
+
+## Documentation
+
+Logstash provides infrastructure to automatically generate documentation for this plugin. We use the asciidoc format to write documentation so any comments in the source code will be first converted into asciidoc and then into html. All plugin documentation are placed under one [central location](http://www.elastic.co/guide/en/logstash/current/).
+
+- For formatting code or config example, you can use the asciidoc `[source,ruby]` directive
+- For more asciidoc formatting tips, see the excellent reference here https://github.com/elastic/docs#asciidoc-guide
+
+## Need Help?
+
+Need help? Try #logstash on freenode IRC or the https://discuss.elastic.co/c/logstash discussion forum.
+
+## Developing
+
+### 1. Plugin Developement and Testing
+
+#### Code
+- To get started, you'll need JRuby with the Bundler gem installed.
+
+- Create a new plugin or clone and existing from the GitHub [logstash-plugins](https://github.com/logstash-plugins) organization. We also provide [example plugins](https://github.com/logstash-plugins?query=example).
+
+- Install dependencies
+```sh
+bundle install
+```
+
+#### Test
+
+- Update your dependencies
+
+```sh
+bundle install
+```
+
+- Run tests
+
+```sh
+bundle exec rspec
+```
+
+### 2. Running your unpublished Plugin in Logstash
+
+#### 2.1 Run in a local Logstash clone
+
+- Edit Logstash `Gemfile` and add the local plugin path, for example:
+```ruby
+gem "logstash-filter-awesome", :path => "/your/local/logstash-filter-awesome"
+```
+- Install plugin
+```sh
+# Logstash 2.3 and higher
+bin/logstash-plugin install --no-verify
+
+# Prior to Logstash 2.3
+bin/plugin install --no-verify
+
+```
+- Run Logstash with your plugin
+```sh
+bin/logstash -e 'filter {awesome {}}'
+```
+At this point any modifications to the plugin code will be applied to this local Logstash setup. After modifying the plugin, simply rerun Logstash.
+
+#### 2.2 Run in an installed Logstash
+
+You can use the same **2.1** method to run your plugin in an installed Logstash by editing its `Gemfile` and pointing the `:path` to your local plugin development directory or you can build the gem and install it using:
+
+- Build your plugin gem
+```sh
+gem build logstash-filter-awesome.gemspec
+```
+- Install the plugin from the Logstash home
+```sh
+# Logstash 2.3 and higher
+bin/logstash-plugin install --no-verify
+
+# Prior to Logstash 2.3
+bin/plugin install --no-verify
+
+```
+- Start Logstash and proceed to test the plugin
+
+## Contributing
+
+All contributions are welcome: ideas, patches, documentation, bug reports, complaints, and even something you drew up on a napkin.
+
+Programming is not a required skill. Whatever you've seen about open source and maintainers or community members  saying "send patches or die" - you will not see that here.
+
+It is more important to the community that you are able to contribute.
+
+For more information about contributing, see the [CONTRIBUTING](https://github.com/elastic/logstash/blob/master/CONTRIBUTING.md) file.

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,7 @@
+@files=[]
+
+task :default do
+  system("rake -T")
+end
+
+require "logstash/devutils/rake"

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# version: 1
+########################################################
+#
+# AUTOMATICALLY GENERATED! DO NOT EDIT
+#
+########################################################
+set -e
+
+echo "Starting build process in: `pwd`"
+source ./ci/setup.sh
+
+if [[ -f "ci/run.sh" ]]; then
+    echo "Running custom build script in: `pwd`/ci/run.sh"
+    source ./ci/run.sh
+else
+    echo "Running default build scripts in: `pwd`/ci/build.sh"
+    bundle install
+    bundle exec rake vendor
+    bundle exec rspec spec
+fi

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# version: 1
+########################################################
+#
+# AUTOMATICALLY GENERATED! DO NOT EDIT
+#
+########################################################
+set -e
+if [ "$LOGSTASH_BRANCH" ]; then
+    echo "Building plugin using Logstash source"
+    BASE_DIR=`pwd`
+    echo "Checking out branch: $LOGSTASH_BRANCH"
+    git clone -b $LOGSTASH_BRANCH https://github.com/elastic/logstash.git ../../logstash --depth 1
+    printf "Checked out Logstash revision: %s\n" "$(git -C ../../logstash rev-parse HEAD)"
+    cd ../../logstash
+    echo "Building plugins with Logstash version:"
+    cat versions.yml
+    echo "---"
+    # We need to build the jars for that specific version
+    echo "Running gradle assemble in: `pwd`"
+    ./gradlew assemble
+    cd $BASE_DIR
+    export LOGSTASH_SOURCE=1
+else
+    echo "Building plugin using released gems on rubygems"
+fi

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,0 +1,86 @@
+:plugin: json_pretty
+:type: codec
+
+///////////////////////////////////////////
+START - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+:version: %VERSION%
+:release_date: %RELEASE_DATE%
+:changelog_url: %CHANGELOG_URL%
+:include_path: ../../../../logstash/docs/include
+///////////////////////////////////////////
+END - GENERATED VARIABLES, DO NOT EDIT!
+///////////////////////////////////////////
+
+[id="plugins-{type}s-{plugin}"]
+
+=== JsonPretty codec plugin
+
+include::{include_path}/plugin_header.asciidoc[]
+
+==== Description
+
+This codec may be used to decode (via inputs) and encode (via outputs) full pretty print JSON messages.
+
+Example of an single line encoded JSON object:
+....
+{"a": 1, "b": {"c": 2, "d": ["x", "y", "z"]}}
+....
+Example of a pretty print encoded JSON object:
+....
+{
+  "a": 1,
+  "b": {
+    "c": 2,
+    "d": ["x", "y", "z" ]
+  }
+}
+....
+
+This codec is intended for use with inputs, like redis or kafka, that produce a single string 'record' - this can be a JSON array of objects or a JSON object that can span multiple lines.
+
+It is *not* intended for use with inputs that produce a chunk of text containing multiple records (events) separated with a newline, like tcp or file.
+If you know that each chunk has only one pretty printed JSON array or object then you can use this codec.
+
+This codec is intended for use with outputs to produce a pretty printed encoded JSON text representation of an event.
+
+If the data being sent is a JSON array at its root, multiple events will be created (one per element).
+
+If you are streaming JSON messages delimited
+by '\n' then see the `json_lines` codec.
+
+If this codec receives a payload from an input that is not valid JSON, then
+it will fall back to plain text and add a tag `_jsonparsefailure`. Upon a JSON
+failure, the payload will be stored in the `message` field.
+
+[NOTE]
+This codec is based on the Logstash JSON codec. It inherits all the options and inner workings of the decode part of the JSON codec but redefines the encode part.
+
+[id="plugins-{type}s-{plugin}-options"]
+==== Json Codec Configuration Options
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<plugins-{type}s-{plugin}-charset>> |<<string,string>>, one of `["ASCII-8BIT", "UTF-8", "US-ASCII", "Big5", "Big5-HKSCS", "Big5-UAO", "CP949", "Emacs-Mule", "EUC-JP", "EUC-KR", "EUC-TW", "GB2312", "GB18030", "GBK", "ISO-8859-1", "ISO-8859-2", "ISO-8859-3", "ISO-8859-4", "ISO-8859-5", "ISO-8859-6", "ISO-8859-7", "ISO-8859-8", "ISO-8859-9", "ISO-8859-10", "ISO-8859-11", "ISO-8859-13", "ISO-8859-14", "ISO-8859-15", "ISO-8859-16", "KOI8-R", "KOI8-U", "Shift_JIS", "UTF-16BE", "UTF-16LE", "UTF-32BE", "UTF-32LE", "Windows-31J", "Windows-1250", "Windows-1251", "Windows-1252", "IBM437", "IBM737", "IBM775", "CP850", "IBM852", "CP852", "IBM855", "CP855", "IBM857", "IBM860", "IBM861", "IBM862", "IBM863", "IBM864", "IBM865", "IBM866", "IBM869", "Windows-1258", "GB1988", "macCentEuro", "macCroatian", "macCyrillic", "macGreek", "macIceland", "macRoman", "macRomania", "macThai", "macTurkish", "macUkraine", "CP950", "CP951", "IBM037", "stateless-ISO-2022-JP", "eucJP-ms", "CP51932", "EUC-JIS-2004", "GB12345", "ISO-2022-JP", "ISO-2022-JP-2", "CP50220", "CP50221", "Windows-1256", "Windows-1253", "Windows-1255", "Windows-1254", "TIS-620", "Windows-874", "Windows-1257", "MacJapanese", "UTF-7", "UTF8-MAC", "UTF-16", "UTF-32", "UTF8-DoCoMo", "SJIS-DoCoMo", "UTF8-KDDI", "SJIS-KDDI", "ISO-2022-JP-KDDI", "stateless-ISO-2022-JP-KDDI", "UTF8-SoftBank", "SJIS-SoftBank", "BINARY", "CP437", "CP737", "CP775", "IBM850", "CP857", "CP860", "CP861", "CP862", "CP863", "CP864", "CP865", "CP866", "CP869", "CP1258", "Big5-HKSCS:2008", "ebcdic-cp-us", "eucJP", "euc-jp-ms", "EUC-JISX0213", "eucKR", "eucTW", "EUC-CN", "eucCN", "CP936", "ISO2022-JP", "ISO2022-JP2", "ISO8859-1", "ISO8859-2", "ISO8859-3", "ISO8859-4", "ISO8859-5", "ISO8859-6", "CP1256", "ISO8859-7", "CP1253", "ISO8859-8", "CP1255", "ISO8859-9", "CP1254", "ISO8859-10", "ISO8859-11", "CP874", "ISO8859-13", "CP1257", "ISO8859-14", "ISO8859-15", "ISO8859-16", "CP878", "MacJapan", "ASCII", "ANSI_X3.4-1968", "646", "CP65000", "CP65001", "UTF-8-MAC", "UTF-8-HFS", "UCS-2BE", "UCS-4BE", "UCS-4LE", "CP932", "csWindows31J", "SJIS", "PCK", "CP1250", "CP1251", "CP1252", "external", "locale"]`|No
+|=======================================================================
+
+&nbsp;
+
+[id="plugins-{type}s-{plugin}-charset"]
+===== `charset` 
+
+  * Value can be any of: `ASCII-8BIT`, `UTF-8`, `US-ASCII`, `Big5`, `Big5-HKSCS`, `Big5-UAO`, `CP949`, `Emacs-Mule`, `EUC-JP`, `EUC-KR`, `EUC-TW`, `GB2312`, `GB18030`, `GBK`, `ISO-8859-1`, `ISO-8859-2`, `ISO-8859-3`, `ISO-8859-4`, `ISO-8859-5`, `ISO-8859-6`, `ISO-8859-7`, `ISO-8859-8`, `ISO-8859-9`, `ISO-8859-10`, `ISO-8859-11`, `ISO-8859-13`, `ISO-8859-14`, `ISO-8859-15`, `ISO-8859-16`, `KOI8-R`, `KOI8-U`, `Shift_JIS`, `UTF-16BE`, `UTF-16LE`, `UTF-32BE`, `UTF-32LE`, `Windows-31J`, `Windows-1250`, `Windows-1251`, `Windows-1252`, `IBM437`, `IBM737`, `IBM775`, `CP850`, `IBM852`, `CP852`, `IBM855`, `CP855`, `IBM857`, `IBM860`, `IBM861`, `IBM862`, `IBM863`, `IBM864`, `IBM865`, `IBM866`, `IBM869`, `Windows-1258`, `GB1988`, `macCentEuro`, `macCroatian`, `macCyrillic`, `macGreek`, `macIceland`, `macRoman`, `macRomania`, `macThai`, `macTurkish`, `macUkraine`, `CP950`, `CP951`, `IBM037`, `stateless-ISO-2022-JP`, `eucJP-ms`, `CP51932`, `EUC-JIS-2004`, `GB12345`, `ISO-2022-JP`, `ISO-2022-JP-2`, `CP50220`, `CP50221`, `Windows-1256`, `Windows-1253`, `Windows-1255`, `Windows-1254`, `TIS-620`, `Windows-874`, `Windows-1257`, `MacJapanese`, `UTF-7`, `UTF8-MAC`, `UTF-16`, `UTF-32`, `UTF8-DoCoMo`, `SJIS-DoCoMo`, `UTF8-KDDI`, `SJIS-KDDI`, `ISO-2022-JP-KDDI`, `stateless-ISO-2022-JP-KDDI`, `UTF8-SoftBank`, `SJIS-SoftBank`, `BINARY`, `CP437`, `CP737`, `CP775`, `IBM850`, `CP857`, `CP860`, `CP861`, `CP862`, `CP863`, `CP864`, `CP865`, `CP866`, `CP869`, `CP1258`, `Big5-HKSCS:2008`, `ebcdic-cp-us`, `eucJP`, `euc-jp-ms`, `EUC-JISX0213`, `eucKR`, `eucTW`, `EUC-CN`, `eucCN`, `CP936`, `ISO2022-JP`, `ISO2022-JP2`, `ISO8859-1`, `ISO8859-2`, `ISO8859-3`, `ISO8859-4`, `ISO8859-5`, `ISO8859-6`, `CP1256`, `ISO8859-7`, `CP1253`, `ISO8859-8`, `CP1255`, `ISO8859-9`, `CP1254`, `ISO8859-10`, `ISO8859-11`, `CP874`, `ISO8859-13`, `CP1257`, `ISO8859-14`, `ISO8859-15`, `ISO8859-16`, `CP878`, `MacJapan`, `ASCII`, `ANSI_X3.4-1968`, `646`, `CP65000`, `CP65001`, `UTF-8-MAC`, `UTF-8-HFS`, `UCS-2BE`, `UCS-4BE`, `UCS-4LE`, `CP932`, `csWindows31J`, `SJIS`, `PCK`, `CP1250`, `CP1251`, `CP1252`, `external`, `locale`
+  * Default value is `"UTF-8"`
+
+The character encoding used in this codec. Examples include "UTF-8" and
+"CP1252".
+
+JSON requires valid UTF-8 strings, but in some cases, software that
+emits JSON does so in another encoding (nxlog, for example). In
+weird cases like this, you can set the `charset` setting to the
+actual encoding of the text and Logstash will convert it for you.
+
+For nxlog users, you may to set this to "CP1252".
+
+

--- a/lib/logstash/codecs/json_pretty.rb
+++ b/lib/logstash/codecs/json_pretty.rb
@@ -1,0 +1,35 @@
+# encoding: utf-8
+require "logstash/codecs/json"
+require "logstash/json"
+require "logstash/event"
+
+# This codec may be used to decode (via inputs) and encode (via outputs) full JSON messages.
+# This codec is intended for use with inputs, like redis or kafka, that produce a single string 'record',
+# this can be a JSON array of objects or a JSON object that can span multiple lines.
+#
+# It is *not* intended for use with inputs, like tcp or file, that produce multiple records (events)
+# separated with a newline. These inputs pass fixed size chunks of text to the codec,
+# if your object is larger than the fixed size, you will get a parse failure.
+#
+# This codec is intended for use with outputs to produce a pretty printed JSON string.
+#
+# If the data being sent is a JSON array at its root multiple events will be created (one per element).
+#
+# If you are streaming JSON messages delimited
+#   by '\n' then see the `json_lines` codec.
+#
+#If this codec receives a payload from an input that is not valid JSON, then
+#   it will fall back to plain text and add a tag `_jsonparsefailure`. Upon a JSON
+#   failure, the payload will be stored in the `message` field.
+
+module LogStash module Codecs class JsonPretty < LogStash::Codecs::JSON
+  config_name "json_pretty"
+
+  # inherit all the decoding from the JSON codec.
+  # the desired effect here is to defeat the fix_streaming_codecs hack in inputs/base.rb
+  # so that this codec can decode multiline pretty print encoded JSON text representations.
+
+  def encode(event)
+    @on_event.call(event, LogStash::Json.dump(event, :pretty => true))
+  end
+end end end

--- a/logstash-codec-json_pretty.gemspec
+++ b/logstash-codec-json_pretty.gemspec
@@ -1,0 +1,30 @@
+Gem::Specification.new do |s|
+
+  s.name            = 'logstash-codec-json_pretty'
+  # this version is the same as the json codec and will probably track it.
+  s.version         = '3.0.4'
+  s.licenses        = ['Apache License (2.0)']
+  s.summary         = "This codec may be used to decode (via inputs) and encode (via outputs) full JSON pretty print messages"
+  s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
+  s.authors         = ["Elastic"]
+  s.email           = 'info@elastic.co'
+  s.homepage        = "http://www.elastic.co/guide/en/logstash/current/index.html"
+  s.require_paths   = ["lib"]
+
+  # Files
+  s.files = Dir["lib/**/*","spec/**/*","*.gemspec","*.md","CONTRIBUTORS","Gemfile","LICENSE","NOTICE.TXT", "vendor/jar-dependencies/**/*.jar", "vendor/jar-dependencies/**/*.rb", "VERSION", "docs/**/*"]
+
+  # Tests
+  s.test_files = s.files.grep(%r{^(test|spec|features)/})
+
+  # Special flag to let us know this is actually a logstash plugin
+  s.metadata = { "logstash_plugin" => "true", "logstash_group" => "codec" }
+
+  # Gem dependencies
+  s.add_runtime_dependency 'logstash-codec-json'
+  # rely on the json codec for logstash-core-plugin-api compatibility
+  # s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
+
+
+  s.add_development_dependency 'logstash-devutils'
+end

--- a/spec/codecs/json_pretty_spec.rb
+++ b/spec/codecs/json_pretty_spec.rb
@@ -1,0 +1,41 @@
+require "logstash/devutils/rspec/spec_helper"
+require "logstash/codecs/json_pretty"
+require "logstash/event"
+require "logstash/json"
+
+describe LogStash::Codecs::JsonPretty do
+  context "#decode" do
+    it "should return an event from json data" do
+      data = {"foo" => "bar", "baz" => {"bah" => ["a","b","c"]}}
+      chunk = LogStash::Json.dump(data, :pretty => true)
+      expect(chunk).to include("\n")
+      subject.decode(chunk) do |event|
+        expect(event).to be_a(LogStash::Event)
+        expect(event.get("foo")).to eq(data["foo"])
+        expect(event.get("baz")).to eq(data["baz"])
+        expect(event.get("bah")).to eq(data["bah"])
+      end
+    end
+  end
+
+  context "#encode" do
+    it "should return json data" do
+      data = {"foo" => "bar", "baz" => {"bah" => ["a","b","c"]}, "@timestamp" => Time.at(0)}
+      event = LogStash::Event.new(data)
+      compared = []
+      compared.push <<-JSON
+{
+  "@timestamp" : "1970-01-01T00:00:00.000Z",
+  "foo" : "bar",
+  "@version" : "1",
+  "baz" : {
+    "bah" : [ "a", "b", "c" ]
+  }
+}
+JSON
+      subject.on_event {|e, d| compared.push(d.concat("\n")) }
+      subject.encode(event)
+      expect(compared.first).to eq(compared.last)
+    end
+  end
+end


### PR DESCRIPTION
I have decided to add this codec to use when the `fix_streaming_codec` hack prevents users from decoding multiline pretty printed JSON encoded text representations from inputs like redis or kafka and the text is known to contain one "record" regardless of how many newline characters are contained within.
I was hoping that Milling would replace the need to do this but it has stalled.